### PR TITLE
remove unused function mkfullpath from windows build

### DIFF
--- a/nvagent/src/config.c
+++ b/nvagent/src/config.c
@@ -29,6 +29,7 @@
 
 static struct agent_cfg *agent_cfg;
 
+#if defined(__unix__) && !defined(__APPLE__)
 static int
 mkfullpath(const char *fullpath)
 {
@@ -52,6 +53,7 @@ mkfullpath(const char *fullpath)
 	}
 	return 0;
 }
+#endif
 
 char *agent_config_get_fullname(const char *profile, const char *file)
 {


### PR DESCRIPTION
This is a quick fix, if you have a better one, please reject.

Explanation: Building netvirt-agent on windows complains about the usage of `mkdir`: 

``` text
nvagent/src/config.c:50:3: error: too many arguments to function ‘mkdir’
```

For i686-w64-mingw32, `mkdir` is declared as:

``` c
int __cdecl mkdir (const char *) __MINGW_ATTRIB_DEPRECATED_MSVC2005;
```

Plus, `mkfullpath` is only used for Linux/BSD
