### PR TITLE
Clone dont fail silently

### DIFF
--- a/build_farm/build-debian.sh
+++ b/build_farm/build-debian.sh
@@ -28,10 +28,12 @@ function submodule () {
 }
 
 function clone_dependencies () {
+    set -e
     clone_or_pull https://github.com/netvirt/netvirt.git netvirt
     cd netvirt
     git submodule init
     git submodule update
+    set +e
 }
 
 function fix_libconfig_git () {

--- a/build_farm/build-mac.sh
+++ b/build_farm/build-mac.sh
@@ -41,10 +41,12 @@ function submodule () {
 }
 
 function clone_dependencies () {
+    set -e
     clone_or_pull https://github.com/netvirt/netvirt.git netvirt
     cd netvirt
     git submodule init
     git submodule update
+    set +e
 }
 
 function fix_libconfig_git () {

--- a/build_farm/build-windows.sh
+++ b/build_farm/build-windows.sh
@@ -66,10 +66,12 @@ function submodule () {
 }
 
 function clone_dependencies () {
+    set -e
     clone_or_pull https://github.com/netvirt/netvirt.git netvirt
     cd netvirt
     git submodule init
     git submodule update
+    set +e
 }
 
 function fix_libconfig_git () {

--- a/build_farm/templates/base.tpl
+++ b/build_farm/templates/base.tpl
@@ -27,10 +27,12 @@ function submodule () {
 }
 
 function clone_dependencies () {
+    set -e
     clone_or_pull https://github.com/netvirt/netvirt.git netvirt
     cd netvirt
     git submodule init
     git submodule update
+    set +e
 }
 
 function fix_libconfig_git () {
@@ -61,4 +63,3 @@ install_build_dependencies
 clone_dependencies
 build_dependencies
 build_nvagent
-

--- a/build_farm/templates/windows.tpl
+++ b/build_farm/templates/windows.tpl
@@ -65,7 +65,7 @@ function install_build_dependencies() {
 
 {% block build_nvagent %}
 function build_nvagent () {
-    build_dir=build.windows.gui
+    build_dir="$PWD/build.windows.gui"
     mcd "$build_dir"
     rm -rf *
     set -e
@@ -77,6 +77,9 @@ function build_nvagent () {
     make netvirt-agent
     makensis -DOPENSSL_PATH="$openssl_dir/mingw32/lib" \
              -DQT_PATH="$qt_root" \
+             -DUDT4_PATH="../udt4" \
+             -DLIBCONFIG_PATH="../libconfig" \
+             -DTAPCFG_PATH="../tapcfg" \
              -DBDIR="$build_dir" \
              ../win32/package_win32.nsi
     rsync *.exe "$release_dir"


### PR DESCRIPTION
I had the case where pulling udt4 would fail because of some local change. Now, the complete build will fail instead of silently moving on.