### PR TITLE
make windows version buildable from Debian Wheezy.

### DIFF
--- a/win32/package_win32.nsi
+++ b/win32/package_win32.nsi
@@ -1,8 +1,8 @@
 !ifndef MINGW_PATH
-	!define MINGW_PATH /usr/lib/gcc/i686-w64-mingw32/4.8/
+	!define MINGW_PATH /usr/lib/gcc/i686-w64-mingw32/4.6
 !endif
 !ifndef PTHREAD_PATH
-	!define PTHREAD_PATH /usr/i686-w64-mingw32/lib/
+	!define PTHREAD_PATH /usr/i686-w64-mingw32/lib
 !endif
 !ifndef OPENSSL_PATH
 	!define OPENSSL_PATH /opt/mingw32/mingw32/bin
@@ -82,7 +82,6 @@ SetCompressor /FINAL /SOLID lzma
 		File ${MINGW_PATH}/libgcc_s_sjlj-1.dll
 		File ${MINGW_PATH}/libstdc++-6.dll
 		File ${MINGW_PATH}/libssp-0.dll
-		File /usr/i686-w64-mingw32/lib/libwinpthread-1.dll
 		File ${PTHREAD_PATH}/pthreadGC2.dll
 		File ${OPENSSL_PATH}/libeay32.dll
 		File ${OPENSSL_PATH}/ssleay32.dll

--- a/win32/package_win32_cli.nsi
+++ b/win32/package_win32_cli.nsi
@@ -1,8 +1,8 @@
 !ifndef MINGW_PATH
-	!define MINGW_PATH /usr/lib/gcc/i686-w64-mingw32/4.8/
+	!define MINGW_PATH /usr/lib/gcc/i686-w64-mingw32/4.6
 !endif
 !ifndef PTHREAD_PATH
-	!define PTHREAD_PATH /usr/i686-w64-mingw32/lib/
+	!define PTHREAD_PATH /usr/i686-w64-mingw32/lib
 !endif
 !ifndef OPENSSL_PATH
 	!define OPENSSL_PATH /opt/mingw32/mingw32/bin
@@ -72,7 +72,6 @@ SetCompressor /FINAL /SOLID lzma
 		File ${MINGW_PATH}/libgcc_s_sjlj-1.dll
 		File ${MINGW_PATH}/libstdc++-6.dll
 		File ${MINGW_PATH}/libssp-0.dll
-		File /usr/i686-w64-mingw32/lib/libwinpthread-1.dll
 		File ${PTHREAD_PATH}/pthreadGC2.dll
 		File ${OPENSSL_PATH}/libeay32.dll
 		File ${OPENSSL_PATH}/ssleay32.dll


### PR DESCRIPTION
The problem was: versions built from Ubuntu 14.04 were crashing at
startup, and building from Wheezy is actually possible.

Use default paths from package gcc-mingw-w64-i686
containing gcc 4.6.3. This version of MinGW gcc does not create a
dependency to libwinpthread-1.dll, so we don't need to embed it
anymore (until the next GCC upgrade :/, which will probably be needed
when we will use a later version of Qt).