### PR TITLE
fix compile error

### DIFF
--- a/nvagent/src/switch.c
+++ b/nvagent/src/switch.c
@@ -99,7 +99,6 @@ struct packets {
 	TAILQ_ENTRY(packets)	 entries;
 };
 
-struct event_base		*ev_base;
 static struct event		*ev_iface = NULL;
 static struct network		*netcf;
 static struct vlink		*vlink = NULL;


### PR DESCRIPTION
/usr/bin/ld: CMakeFiles/netvirt-agent2.dir/cli/main.c.o:(.bss+0x0): multiple definition of `ev_base'; CMakeFiles/netvirt-agent2.dir/switch.c.o:(.bss+0x10): first defined here